### PR TITLE
现在能正确识别斗鱼是直播还是录播

### DIFF
--- a/biliup/plugins/douyu.py
+++ b/biliup/plugins/douyu.py
@@ -1,7 +1,9 @@
 import platform
+import json
 
 from ykdl.common import url_to_module
 from ykdl.util.jsengine import chakra_available, quickjs_available, external_interpreter
+from ykdl.util.html import get_content
 
 from ..engine.decorators import Plugin
 from ..plugins import logger
@@ -30,4 +32,11 @@ class Douyu(DownloadBase):
         urls = info.streams[stream_id]['src']
         self.raw_stream_url = urls[0]
         # print(info.title)
-        return True
+        douyuurl = self.url
+        roomnum = douyuurl.split("douyu.com/")[1]
+        roomloop = json.loads(get_content('https://www.douyu.com/wgapi/live/liveweb/getRoomLoopInfo?rid='+roomnum))
+        roomvid = roomloop['data']['vid']
+        if roomvid != "":
+            return False
+        else:
+            return True


### PR DESCRIPTION
增加了一个参数判断是直播还是录播
https://www.douyu.com/wgapi/live/liveweb/getRoomLoopInfo?rid=房间号
如果vid不为空，则是录播状态，为空则属于直播或者未开播状态